### PR TITLE
fix: types.StringTypes replacement

### DIFF
--- a/fissix/tests/test_fixers.py
+++ b/fissix/tests/test_fixers.py
@@ -3404,7 +3404,7 @@ class Test_types(FixerTestCase):
         self.check(b, a)
 
         b = "types.StringTypes"
-        a = "(str,)"
+        a = "six.string_types"
         self.check(b, a)
 
 


### PR DESCRIPTION
Hello.

The library provides only one type insted of two string types in Python 2 when replacing types.StringTypes. This results in incorrect behavior after applying the library.

### Description

```python
if isinstance(inputValue, types.StringTypes) and isinstance(outputValue, types.StringTypes):  # before
if isinstance(inputValue, (str,)) and isinstance(outputValue, (str,)):  # after
```

Fixes: #

```python
if isinstance(inputValue, six.string_types) and isinstance(outputValue, six.string_types):
```

From the documentation:
https://docs.python.org/2/library/types.html

> **types.StringTypes**
>  A sequence containing StringType and UnicodeType used to facilitate easier checking for any string object.

From the six library code:
https://github.com/benjaminp/six/blob/master/six.py

 In Python2, basestring is the base class of str and unicode types.

```python
if PY3:
    string_types = str,
    ...
else:
    string_types = basestring
   ...
```

And it does not work properly in Python2 after changing original code

```python
if isinstance(inputValue, (str,)) and isinstance(outputValue, (str,)):
```
