### PR TITLE
GitHub Actions: What will happen on Py3.13 with no lib2to3?

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [macOS-13, ubuntu-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [macos-13, macos-14, ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install
         run: make EXTRAS=dev install
       - name: Test


### PR DESCRIPTION
# DRAFT pull request.  Just an experiment!

Python 3.12 beta 6 has no `lib2to3` so what are the test results?

`macos-13` is Intel X64 while `macos-14` is ARM64 Apple Silicon
* Python 3.8 and 3.9 are not supported on ARM64 Apple Silicon.

---

* #39

# The tests seem to pass on Python 3.13 beta.  Closing.