### PR TITLE
replace deprecated appdirs with platfromdirs fork

### DIFF
--- a/fissix/__init__.py
+++ b/fissix/__init__.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from appdirs import user_cache_dir
+from platformdirs import user_cache_dir
 
 from .__version__ import __version__
 from .pgen2 import driver, grammar, pgen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "appdirs >= 1.4.4",
+    "platformdirs >= 1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1067992

python3-appdirs is dead upstream[1] and its Debian maintainer has indicated
that it should not be included in trixie[2]. A recommended replacement is
python3-platformdirs[3], which is a fork of appdirs with a very similar API.

Please migrate from appdirs to platformdirs or some other replacement,
so that appdirs can be removed.