### PR TITLE
Replace deprecated os.path.commonprefix() with os.path.commonpath()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - name: Install
+        if: matrix.python-version != '3.15'
         run: make EXTRAS=dev install
+      - name: Install (test only)
+        if: matrix.python-version == '3.15'
+        run: |
+          python -m pip install -U pip
+          python -m pip install -Ue .
+          python -m pip install pytest
       - name: Test
         run: make test
       - name: Lint
+        if: matrix.python-version != '3.15'
         run: make lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [macOS-13, ubuntu-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set Up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install
         run: make EXTRAS=dev install
       - name: Test

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,9 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.14"
 python:
   install:
     - method: pip

--- a/fissix/fixer_util.py
+++ b/fissix/fixer_util.py
@@ -8,7 +8,6 @@ from .pytree import Leaf, Node
 from .pygram import python_symbols as syms
 from . import patcomp
 
-
 ###########################################################
 ### Common node-construction "macros"
 ###########################################################

--- a/fissix/fixes/fix_asserts.py
+++ b/fissix/fixes/fix_asserts.py
@@ -27,9 +27,7 @@ class FixAsserts(BaseFix):
 
     PATTERN = """
               power< any+ trailer< '.' meth=(%s)> any* >
-              """ % "|".join(
-        map(repr, NAMES)
-    )
+              """ % "|".join(map(repr, NAMES))
 
     def transform(self, node, results):
         name = results["meth"][0]

--- a/fissix/fixes/fix_dict.py
+++ b/fissix/fixes/fix_dict.py
@@ -34,7 +34,6 @@ from .. import fixer_base
 from ..fixer_util import Name, Call, Dot
 from .. import fixer_util
 
-
 iter_exempt = fixer_util.consuming_calls | {"iter"}
 
 

--- a/fissix/fixes/fix_except.py
+++ b/fissix/fixes/fix_except.py
@@ -59,7 +59,7 @@ class FixExcept(fixer_base.BaseFix):
                 len(except_clause.children) == 4
                 and except_clause.children[2].value != "as"
             ):
-                (E, comma, N) = except_clause.children[1:4]
+                E, comma, N = except_clause.children[1:4]
                 comma.replace(Name("as", prefix=" "))
                 changed = True
 

--- a/fissix/fixes/fix_imports2.py
+++ b/fissix/fixes/fix_imports2.py
@@ -3,7 +3,6 @@ fix_imports."""
 
 from . import fix_imports
 
-
 MAPPING = {"whichdb": "dbm", "anydbm": "dbm"}
 
 

--- a/fissix/fixes/fix_input.py
+++ b/fissix/fixes/fix_input.py
@@ -7,7 +7,6 @@ from .. import fixer_base
 from ..fixer_util import Call, Name
 from .. import patcomp
 
-
 context = patcomp.compile_pattern("power< 'eval' trailer< '(' any ')' > >")
 
 

--- a/fissix/fixes/fix_itertools.py
+++ b/fissix/fixes/fix_itertools.py
@@ -1,11 +1,11 @@
-""" Fixer for itertools.(imap|ifilter|izip) --> (map|filter|zip) and
-    itertools.ifilterfalse --> itertools.filterfalse (bugs 2360-2363)
+"""Fixer for itertools.(imap|ifilter|izip) --> (map|filter|zip) and
+itertools.ifilterfalse --> itertools.filterfalse (bugs 2360-2363)
 
-    imports from itertools are fixed in fix_itertools_import.py
+imports from itertools are fixed in fix_itertools_import.py
 
-    If itertools is imported as something else (ie: import itertools as it;
-    it.izip(spam, eggs)) method calls will not get fixed.
-    """
+If itertools is imported as something else (ie: import itertools as it;
+it.izip(spam, eggs)) method calls will not get fixed.
+"""
 
 # Local imports
 from .. import fixer_base
@@ -21,9 +21,7 @@ class FixItertools(fixer_base.BaseFix):
                      dot='.' func=%(it_funcs)s > trailer< '(' [any] ')' > >
               |
               power< func=%(it_funcs)s trailer< '(' [any] ')' > >
-              """ % (
-        locals()
-    )
+              """ % (locals())
 
     # Needs to be run after fix_(map|zip|filter)
     run_order = 6

--- a/fissix/fixes/fix_itertools_imports.py
+++ b/fissix/fixes/fix_itertools_imports.py
@@ -1,4 +1,4 @@
-""" Fixer for imports of itertools.(imap|ifilter|izip|ifilterfalse) """
+"""Fixer for imports of itertools.(imap|ifilter|izip|ifilterfalse)"""
 
 # Local imports
 from fissix import fixer_base
@@ -9,9 +9,7 @@ class FixItertoolsImports(fixer_base.BaseFix):
     BM_compatible = True
     PATTERN = """
               import_from< 'from' 'itertools' 'import' imports=any >
-              """ % (
-        locals()
-    )
+              """ % (locals())
 
     def transform(self, node, results):
         imports = results["imports"]

--- a/fissix/fixes/fix_long.py
+++ b/fissix/fixes/fix_long.py
@@ -1,8 +1,7 @@
 # Copyright 2006 Google, Inc. All Rights Reserved.
 # Licensed to PSF under a Contributor Agreement.
 
-"""Fixer that turns 'long' into 'int' everywhere.
-"""
+"""Fixer that turns 'long' into 'int' everywhere."""
 
 # Local imports
 from fissix import fixer_base

--- a/fissix/fixes/fix_metaclass.py
+++ b/fissix/fixes/fix_metaclass.py
@@ -1,18 +1,18 @@
 """Fixer for __metaclass__ = X -> (metaclass=X) methods.
 
-   The various forms of classef (inherits nothing, inherits once, inherits
-   many) don't parse the same in the CST so we look at ALL classes for
-   a __metaclass__ and if we find one normalize the inherits to all be
-   an arglist.
+The various forms of classef (inherits nothing, inherits once, inherits
+many) don't parse the same in the CST so we look at ALL classes for
+a __metaclass__ and if we find one normalize the inherits to all be
+an arglist.
 
-   For one-liner classes ('class X: pass') there is no indent/dedent so
-   we normalize those into having a suite.
+For one-liner classes ('class X: pass') there is no indent/dedent so
+we normalize those into having a suite.
 
-   Moving the __metaclass__ into the classdef can also cause the class
-   body to be empty so there is some special casing for that as well.
+Moving the __metaclass__ into the classdef can also cause the class
+body to be empty so there is some special casing for that as well.
 
-   This fixer also tries very hard to keep original indenting and spacing
-   in all those corner cases.
+This fixer also tries very hard to keep original indenting and spacing
+in all those corner cases.
 
 """
 

--- a/fissix/fixes/fix_methodattrs.py
+++ b/fissix/fixes/fix_methodattrs.py
@@ -1,5 +1,4 @@
-"""Fix bound method attributes (method.im_? -> method.__?__).
-"""
+"""Fix bound method attributes (method.im_? -> method.__?__)."""
 
 # Author: Christian Heimes
 

--- a/fissix/fixes/fix_numliterals.py
+++ b/fissix/fixes/fix_numliterals.py
@@ -1,5 +1,4 @@
-"""Fixer that turns 1L into 1, 0755 into 0o755.
-"""
+"""Fixer that turns 1L into 1, 0755 into 0o755."""
 
 # Copyright 2007 Georg Brandl.
 # Licensed to PSF under a Contributor Agreement.

--- a/fissix/fixes/fix_operator.py
+++ b/fissix/fixes/fix_operator.py
@@ -39,9 +39,7 @@ class FixOperator(fixer_base.BaseFix):
                 trailer< '.' %(methods)s > trailer< %(obj)s > >
               |
               power< %(methods)s trailer< %(obj)s > >
-              """ % dict(
-        methods=methods, obj=obj
-    )
+              """ % dict(methods=methods, obj=obj)
 
     def transform(self, node, results):
         method = self._check_method(node, results)

--- a/fissix/fixes/fix_print.py
+++ b/fissix/fixes/fix_print.py
@@ -20,7 +20,6 @@ from ..pgen2 import token
 from .. import fixer_base
 from ..fixer_util import Name, Call, Comma, String
 
-
 parend_expr = patcomp.compile_pattern("""atom< '(' [atom|STRING|NAME] ')' >""")
 
 

--- a/fissix/fixes/fix_sys_exc.py
+++ b/fissix/fixes/fix_sys_exc.py
@@ -18,9 +18,7 @@ class FixSysExc(fixer_base.BaseFix):
     BM_compatible = True
     PATTERN = """
               power< 'sys' trailer< dot='.' attribute=(%s) > >
-              """ % "|".join(
-        "'%s'" % e for e in exc_info
-    )
+              """ % "|".join("'%s'" % e for e in exc_info)
 
     def transform(self, node, results):
         sys_attr = results["attribute"][0]

--- a/fissix/fixes/fix_urllib.py
+++ b/fissix/fixes/fix_urllib.py
@@ -1,6 +1,6 @@
 """Fix changes imports of urllib which are now incompatible.
-   This is rather similar to fix_imports, but because of the more
-   complex nature of the fixing for urllib, it has its own fixer.
+This is rather similar to fix_imports, but because of the more
+complex nature of the fixing for urllib, it has its own fixer.
 """
 
 # Author: Nick Edds

--- a/fissix/main.py
+++ b/fissix/main.py
@@ -295,16 +295,13 @@ def main(fixer_pkg, args=None):
     else:
         requested = avail_fixes.union(explicit)
     fixer_names = requested.difference(unwanted_fixes)
-    input_base_dir = os.path.commonprefix(args)
-    if (
-        input_base_dir
-        and not input_base_dir.endswith(os.sep)
-        and not os.path.isdir(input_base_dir)
-    ):
-        # One or more similar names were passed, their directory is the base.
-        # os.path.commonprefix() is ignorant of path elements, this corrects
-        # for that weird API.
-        input_base_dir = os.path.dirname(input_base_dir)
+    if args:
+        input_base_dir = os.path.commonpath(args)
+        if not os.path.isdir(input_base_dir):
+            # args are filenames, use their common parent directory.
+            input_base_dir = os.path.dirname(input_base_dir)
+    else:
+        input_base_dir = ""
     if options.output_dir:
         input_base_dir = input_base_dir.rstrip(os.sep)
         logger.info(

--- a/fissix/pgen2/tokenize.py
+++ b/fissix/pgen2/tokenize.py
@@ -173,8 +173,8 @@ class StopTokenizing(Exception):
 
 
 def printtoken(type, token, xxx_todo_changeme, xxx_todo_changeme1, line):  # for testing
-    (srow, scol) = xxx_todo_changeme
-    (erow, ecol) = xxx_todo_changeme1
+    srow, scol = xxx_todo_changeme
+    erow, ecol = xxx_todo_changeme1
     print(
         "%d,%d-%d,%d:\t%s\t%s" % (srow, scol, erow, ecol, tok_name[type], repr(token))
     )

--- a/fissix/tests/test_fixers.py
+++ b/fissix/tests/test_fixers.py
@@ -1,4 +1,4 @@
-""" Test suite for the fixer modules """
+"""Test suite for the fixer modules"""
 
 # Python imports
 import os
@@ -56,7 +56,7 @@ class FixerTestCase(support.TestCase):
         fixes = [self.fixer]
         fixes.extend(names)
         r = support.get_refactorer("fissix", fixes)
-        (pre, post) = r.get_fixers()
+        pre, post = r.get_fixers()
         n = "fix_" + self.fixer
         if post and post[-1].__class__.__module__.endswith(n):
             # We're the last fixer to run
@@ -1813,9 +1813,7 @@ class ImportsFixerTests:
             s = """
                 def f():
                     %s.method()
-                """ % (
-                old,
-            )
+                """ % (old,)
             self.unchanged(s)
 
             # test nested usage

--- a/fissix/tests/test_main.py
+++ b/fissix/tests/test_main.py
@@ -13,7 +13,6 @@ import pytest
 
 from fissix import main
 
-
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 PY2_TEST_MODULE = os.path.join(TEST_DATA_DIR, "py2_test_grammar.py")
 

--- a/fissix/tests/test_parser.py
+++ b/fissix/tests/test_parser.py
@@ -33,7 +33,7 @@ from fissix.pygram import python_symbols as syms
 
 class TestDriver(support.TestCase):
     def test_formfeed(self):
-        s = """print 1\n\x0Cprint 2\n"""
+        s = """print 1\n\x0cprint 2\n"""
         t = driver.parse_string(s)
         self.assertEqual(t.children[0].children[0].type, syms.print_stmt)
         self.assertEqual(t.children[1].children[0].type, syms.print_stmt)
@@ -91,8 +91,7 @@ class TestPgen2Caching(support.TestCase):
                     """
 from fissix.pgen2 import driver as pgen2_driver
 pgen2_driver.load_grammar(%r, save=True, force=True)
-                    """
-                    % (grammar_sub_copy,),
+                    """ % (grammar_sub_copy,),
                 ],
                 env=sub_env,
             )
@@ -155,71 +154,53 @@ class TestYieldFrom(GrammarTest):
 
 class TestAsyncAwait(GrammarTest):
     def test_await_expr(self):
-        self.validate(
-            """async def foo():
+        self.validate("""async def foo():
                              await x
-                      """
-        )
+                      """)
 
-        self.validate(
-            """async def foo():
+        self.validate("""async def foo():
                              [i async for i in b]
-                      """
-        )
+                      """)
 
-        self.validate(
-            """async def foo():
+        self.validate("""async def foo():
                              {i for i in b
                                 async for i in a if await i
                                   for b in i}
-                      """
-        )
+                      """)
 
-        self.validate(
-            """async def foo():
+        self.validate("""async def foo():
                              [await i for i in b if await c]
-                      """
-        )
+                      """)
 
-        self.validate(
-            """async def foo():
+        self.validate("""async def foo():
                              [ i for i in b if c]
-                      """
-        )
+                      """)
 
-        self.validate(
-            """async def foo():
+        self.validate("""async def foo():
 
             def foo(): pass
 
             def foo(): pass
 
             await x
-        """
-        )
+        """)
 
         self.validate("""async def foo(): return await a""")
 
-        self.validate(
-            """def foo():
+        self.validate("""def foo():
             def foo(): pass
             async def foo(): await x
-        """
-        )
+        """)
 
         self.invalid_syntax("await x")
-        self.invalid_syntax(
-            """def foo():
-                                   await x"""
-        )
+        self.invalid_syntax("""def foo():
+                                   await x""")
 
-        self.invalid_syntax(
-            """def foo():
+        self.invalid_syntax("""def foo():
             def foo(): pass
             async def foo(): pass
             await x
-        """
-        )
+        """)
 
     def test_async_var(self):
         self.validate("""async = 1""")
@@ -227,26 +208,18 @@ class TestAsyncAwait(GrammarTest):
         self.validate("""def async(): pass""")
 
     def test_async_with(self):
-        self.validate(
-            """async def foo():
-                             async for a in b: pass"""
-        )
+        self.validate("""async def foo():
+                             async for a in b: pass""")
 
-        self.invalid_syntax(
-            """def foo():
-                                   async for a in b: pass"""
-        )
+        self.invalid_syntax("""def foo():
+                                   async for a in b: pass""")
 
     def test_async_for(self):
-        self.validate(
-            """async def foo():
-                             async with a: pass"""
-        )
+        self.validate("""async def foo():
+                             async with a: pass""")
 
-        self.invalid_syntax(
-            """def foo():
-                                   async with a: pass"""
-        )
+        self.invalid_syntax("""def foo():
+                                   async with a: pass""")
 
 
 class TestRaiseChanges(GrammarTest):

--- a/fissix/tests/test_refactor.py
+++ b/fissix/tests/test_refactor.py
@@ -14,7 +14,6 @@ import unittest
 from fissix import refactor, pygram, fixer_base
 from fissix.pgen2 import token
 
-
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 FIXER_DIR = os.path.join(TEST_DATA_DIR, "fixers")
 

--- a/fissix/tests/test_util.py
+++ b/fissix/tests/test_util.py
@@ -1,4 +1,4 @@
-""" Test suite for the code in fixer_util """
+"""Test suite for the code in fixer_util"""
 
 # Testing imports
 from . import support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,14 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "attribution==1.8.0",
-    "black==24.8.0",
-    "flit==3.9.0",
-    "pytest==8.3.3",
-    "ufmt==2.7.3",
-    "usort==1.0.8.post1",
+    "black==26.3.1",
+    "flit==3.12.0",
+    "pytest==9.0.2",
+    "ufmt==2.9.1",
+    "usort==1.1.3",
 ]
 docs = [
-    "sphinx==8.0.2",
+    "sphinx==9.1.0",
     "sphinx-mdinclude==0.6.2",
 ]
 


### PR DESCRIPTION
os.path.commonprefix() is deprecated in Python 3.15. Replace it with os.path.commonpath() which is path-element-aware and doesn't need the manual correction that was needed for commonprefix's character-level prefix matching.

Handle the empty args case explicitly since commonpath raises ValueError on empty sequences while commonprefix returns ''.

### Description

<describe bug fix or new feature>

Fixes: #83 
