### PR TITLE
Replace deprecated os.path.commonprefix() with os.path.commonpath()

### DIFF
--- a/fissix/main.py
+++ b/fissix/main.py
@@ -295,16 +295,13 @@ def main(fixer_pkg, args=None):
     else:
         requested = avail_fixes.union(explicit)
     fixer_names = requested.difference(unwanted_fixes)
-    input_base_dir = os.path.commonprefix(args)
-    if (
-        input_base_dir
-        and not input_base_dir.endswith(os.sep)
-        and not os.path.isdir(input_base_dir)
-    ):
-        # One or more similar names were passed, their directory is the base.
-        # os.path.commonprefix() is ignorant of path elements, this corrects
-        # for that weird API.
-        input_base_dir = os.path.dirname(input_base_dir)
+    if args:
+        input_base_dir = os.path.commonpath(args)
+        if not os.path.isdir(input_base_dir):
+            # args are filenames, use their common parent directory.
+            input_base_dir = os.path.dirname(input_base_dir)
+    else:
+        input_base_dir = ""
     if options.output_dir:
         input_base_dir = input_base_dir.rstrip(os.sep)
         logger.info(


### PR DESCRIPTION
os.path.commonprefix() is deprecated since Python 3.15 and scheduled for removal in Python 3.17. It also has a well-known flaw: it operates on characters rather than path components.

Replace it with os.path.commonpath(), which works correctly with path components. Guard against empty args (commonpath raises ValueError on empty sequences) by checking args before calling it.

### Description

<describe bug fix or new feature>

Fixes: #
